### PR TITLE
Bugfix: Large Trade orders failing

### DIFF
--- a/app/src/Sidebar/Buy/index.js
+++ b/app/src/Sidebar/Buy/index.js
@@ -143,7 +143,6 @@ const Buy = ({
       investmentAmountInUnits = zeroDecimal;
     }
 
-    /*
     if (investmentAmountInUnits.gt(collateralBalance.totalAmount.toString()))
       throw new Error(
         `Not enough collateral: missing ${formatCollateral(
@@ -151,7 +150,6 @@ const Buy = ({
           collateral
         )}`
       );
-      */
 
     const tradeAmounts = stagedTradeAmounts.map(amount => amount.toString());
     const collateralLimit = await marketMakersRepo.calcNetCost(tradeAmounts);

--- a/app/src/Sidebar/Buy/index.js
+++ b/app/src/Sidebar/Buy/index.js
@@ -143,6 +143,7 @@ const Buy = ({
       investmentAmountInUnits = zeroDecimal;
     }
 
+    /*
     if (investmentAmountInUnits.gt(collateralBalance.totalAmount.toString()))
       throw new Error(
         `Not enough collateral: missing ${formatCollateral(
@@ -150,6 +151,7 @@ const Buy = ({
           collateral
         )}`
       );
+      */
 
     const tradeAmounts = stagedTradeAmounts.map(amount => amount.toString());
     const collateralLimit = await marketMakersRepo.calcNetCost(tradeAmounts);

--- a/app/src/components/Toasts.scss
+++ b/app/src/components/Toasts.scss
@@ -4,6 +4,7 @@
   position: fixed;
   right: 5rem;
   bottom: 5rem;
+  line-height: normal;
 
   .toast {
     background-color: $white;

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -20,6 +20,7 @@ import { history, store } from "./store";
 
 Decimal.config({
   precision: 80,
+  toExpPos: 50,
   rounding: Decimal.ROUND_FLOOR
 });
 


### PR DESCRIPTION
Large trade orders were failing because the numbers generated were so big that Decimal.js truncated the exponent. This also fixes the weird line-height on the alert/toast messages.