### PR TITLE
Feature #50, #52: Show last trade from history instead currenty probability

### DIFF
--- a/app/src/MarketTable/CategoricalMarketTable/MarketRow/index.js
+++ b/app/src/MarketTable/CategoricalMarketTable/MarketRow/index.js
@@ -143,6 +143,7 @@ const Market = ({
         created={created}
         colSpan={headings.length}
         probabilities={probabilities}
+        resolutionDate={resolutionDate}
         stagedProbabilities={stagedProbabilities}
       ></ProbabilityChart>
       <tr

--- a/app/src/MarketTable/CategoricalMarketTable/MarketRow/probabilityChart.js
+++ b/app/src/MarketTable/CategoricalMarketTable/MarketRow/probabilityChart.js
@@ -20,6 +20,7 @@ const probabilityChart = ({
   marketType,
   colSpan,
   probabilities,
+  resolutionDate,
   stagedProbabilities
 }) => {
   const { loading, error, data } = useQuery(GET_TRADES_BY_MARKET_MAKER, {
@@ -80,6 +81,7 @@ const probabilityChart = ({
               upperBound={"100"}
               decimals={0}
               entries={parsedTrades}
+              resolutionDate={resolutionDate}
               currentProbability={displayedProbabilities}
               marketType={marketType}
               created={created}
@@ -96,6 +98,7 @@ probabilityChart.propTypes = {
   created: PropTypes.string.isRequired,
   marketType: PropTypes.string.isRequired,
   colSpan: PropTypes.number.isRequired,
+  resolutionDate: PropTypes.string.isRequired,
   probabilities: PropTypes.array,
   stagedProbabilities: PropTypes.array
 };

--- a/app/src/MarketTable/ScalarMarketTable/index.js
+++ b/app/src/MarketTable/ScalarMarketTable/index.js
@@ -193,6 +193,7 @@ const MarketTable = ({
                   decimals={decimals}
                   unit={unit}
                   entries={trades}
+                  resolutionDate={resolutionDate}
                   created={created}
                   currentProbability={parsedProbabilities}
                   marketType={type}

--- a/app/src/components/Graph.js
+++ b/app/src/components/Graph.js
@@ -1,10 +1,4 @@
-import React, {
-  useEffect,
-  useState,
-  useCallback,
-  useRef,
-  useMemo
-} from "react";
+import React, { useEffect, useState, useCallback, useRef } from "react";
 import PropTypes from "prop-types";
 import { formatDate, getMoment } from "utils/timeFormat";
 import { formatScalarValue } from "utils/formatting";
@@ -102,15 +96,15 @@ const TooltipContent = ({ active, value, payload, unit, decimals }) => {
 const Graph = ({
   lowerBound,
   upperBound,
-  decimals: parentDecimals,
+  decimals,
   unit,
-  entries,
   created,
   resolutionDate,
-  currentProbability,
-  marketType
+  marketType,
+  entries,
+  currentProbability
 }) => {
-  const [decimals, setDecimals] = useState(parentDecimals || 2);
+  //const [decimals, setDecimals] = useState(parentDecimals || 2);
 
   const [data, setData] = useState(entries);
   const [sidebarWidth, setSidebarWidth] = useState(0);
@@ -121,7 +115,8 @@ const Graph = ({
   const lineRef = useRef(null);
   const lineChartRef = useRef(null);
 
-  useMemo(() => {
+  useEffect(() => {
+    // console.log("memo updates", entries, currentProbability)
     // TODO entries and currentProbability are constantly updating. As data
     // object is updated each render the graph is re-rendered continously.
     // Check how to cache entries and current probability to avoid components
@@ -167,6 +162,13 @@ const Graph = ({
           outcomesProbability: currentProbability,
           date: +new Date(),
           index: entries.length + 1 // +1 because we add the market creation as a datapoint
+        });
+      } else {
+        // when market is resolved, duplicate latest trade but adjust to show on resolution date
+        newData.push({
+          ...entries[entries.length - 1],
+          date: getMoment(resolutionDate).valueOf(),
+          index: entries.length + 1
         });
       }
 
@@ -354,7 +356,15 @@ Graph.propTypes = {
   upperBound: PropTypes.string.isRequired,
   entries: PropTypes.array,
   currentProbability: PropTypes.array,
-  marketType: PropTypes.string.isRequired
+  marketType: PropTypes.string.isRequired,
+  resolutionDate: PropTypes.string.isRequired,
+  created: PropTypes.string.isRequired,
+  decimals: PropTypes.number.isRequired,
+  unit: PropTypes.string
+};
+
+Graph.defaultProps = {
+  unit: "Units"
 };
 
 export default Graph;

--- a/app/src/components/Graph.js
+++ b/app/src/components/Graph.js
@@ -9,6 +9,7 @@ import PropTypes from "prop-types";
 import { formatDate, getMoment } from "utils/timeFormat";
 import { formatScalarValue } from "utils/formatting";
 import cn from "classnames/bind";
+import moment from "moment";
 
 import styles from "./Graph.scss";
 
@@ -106,6 +107,7 @@ const Graph = ({
   unit,
   entries,
   created,
+  resolutionDate,
   currentProbability,
   marketType
 }) => {
@@ -157,13 +159,17 @@ const Graph = ({
           // with the same index. Is not critical but it's a bug
           index: 0
         },
-        ...entries,
-        {
+        ...entries
+      ];
+
+      if (moment(resolutionDate).isAfter(moment())) {
+        // only add last entry (with currently probabilities) if the market is not already resolved
+        newData.push({
           outcomesProbability: currentProbability,
           date: +new Date(),
           index: entries.length + 1 // +1 because we add the market creation as a datapoint
-        }
-      ];
+        });
+      }
 
       setData(newData);
     }

--- a/app/src/components/Graph.js
+++ b/app/src/components/Graph.js
@@ -9,7 +9,6 @@ import PropTypes from "prop-types";
 import { formatDate, getMoment } from "utils/timeFormat";
 import { formatScalarValue } from "utils/formatting";
 import cn from "classnames/bind";
-import moment from "moment";
 
 import styles from "./Graph.scss";
 
@@ -162,7 +161,7 @@ const Graph = ({
         ...entries
       ];
 
-      if (moment(resolutionDate).isAfter(moment())) {
+      if (getMoment(resolutionDate).isAfter(getMoment())) {
         // only add last entry (with currently probabilities) if the market is not already resolved
         newData.push({
           outcomesProbability: currentProbability,

--- a/app/src/conf/config.rinkeby.json
+++ b/app/src/conf/config.rinkeby.json
@@ -1,4 +1,4 @@
 {
-  "lmsrAddress": "0xf742a2358be6f9bdBCE91f119f3e8f9620f3F028",
+  "lmsrAddress": "0x1Fb75d36bfdd9906274b6565dbBe3813eB3eD276",
   "networkId": 4
 }


### PR DESCRIPTION
# Description
This PR adds two features, to improve usability:
- Hide "current probability" from graph when the market is already resolved or has ended.
- Display the "last trade" with the date of the resolution to show the final probabilities when this market was resolved.

# To test
- View a very old closed market, notice the graph ends on the date of the resolution

# Code
/

⚠️ **Please merge #129 before merging this!!!!!!** ⚠️ 