### PR TITLE
Feature/#68 web3connect cache to keep session

### DIFF
--- a/app/src/Root/index.js
+++ b/app/src/Root/index.js
@@ -12,7 +12,7 @@ import makeLoadable from "utils/make-loadable";
 import { getAccount, loadWeb3 } from "utils/web3";
 import { loadMarketsData } from "utils/getMarketsData";
 import ToastifyError from "utils/ToastifyError";
-import web3Modal from "utils/web3Modal";
+import getWeb3Modal from "utils/web3Modal";
 
 import { getUserState, getTiersLimit } from "api/onboarding";
 import { GET_TRADES_BY_MARKET_MAKER } from "api/thegraph";
@@ -123,6 +123,8 @@ const RootComponent = ({
     ? match.params.lmsrAddress
     : conf.lmsrAddress;
 
+  const web3Modal = getWeb3Modal(lmsrAddress);
+
   const init = useCallback(
     async provider => {
       try {
@@ -188,7 +190,7 @@ const RootComponent = ({
     if (loading !== "LOADING") {
       // we already init app once. We have to clear data
       setLoading("LOADING");
-      // setCollateral(null);
+      setCollateral(null);
       setMarkets(null);
       setUser(null);
       setConditionalTokensService(null);
@@ -510,6 +512,7 @@ const RootComponent = ({
             avatar={
               <UserWallet
                 address={account}
+                lmsrAddress={lmsrAddress}
                 openModal={openModal}
                 whitelistState={whitelistState}
                 collateral={collateral}

--- a/app/src/components/UserWallet.js
+++ b/app/src/components/UserWallet.js
@@ -1,13 +1,11 @@
 import React, { useEffect, useCallback } from "react";
 import PropTypes from "prop-types";
 import cn from "classnames/bind";
-import Web3Modal from "web3modal";
 import Blockies from "react-blockies";
-
-import WalletConnectProvider from "@walletconnect/web3-provider";
 
 import useGlobalState from "hooks/useGlobalState";
 import { formatAddress } from "utils/formatting";
+import web3Modal from "utils/web3Modal";
 
 import conf from "conf";
 
@@ -22,19 +20,6 @@ const ONBOARDING_MODE = conf.ONBOARDING_MODE;
 const accountsEnabled = ONBOARDING_MODE === "TIERED";
 
 const cx = cn.bind(style);
-
-const web3Modal = new Web3Modal({
-  network: conf.network,
-  // cacheProvider: true,
-  providerOptions: {
-    walletconnect: {
-      package: WalletConnectProvider,
-      options: {
-        infuraId: "d743990732244555a1a0e82d5ab90c7f"
-      }
-    }
-  }
-});
 
 // Logged In common components
 const LoggedIn = ({ address, collateral, collateralBalance, disconnect }) => {
@@ -96,7 +81,7 @@ const UserWallet = ({
   );
 
   const disconnect = useCallback(() => {
-    // web3Modal.clearCachedProvider();
+    web3Modal.clearCachedProvider();
     setProvider(null);
   });
 
@@ -104,7 +89,7 @@ const UserWallet = ({
     web3Modal.on("connect", connect);
 
     web3Modal.on("disconnect", () => {
-      // disconnect();
+      disconnect();
     });
 
     web3Modal.on("close", () => {});

--- a/app/src/components/UserWallet.js
+++ b/app/src/components/UserWallet.js
@@ -5,7 +5,7 @@ import Blockies from "react-blockies";
 
 import useGlobalState from "hooks/useGlobalState";
 import { formatAddress } from "utils/formatting";
-import web3Modal from "utils/web3Modal";
+import getWeb3Modal from "utils/web3Modal";
 
 import conf from "conf";
 
@@ -65,6 +65,7 @@ LoggedIn.propTypes = {
 
 const UserWallet = ({
   //address,
+  lmsrAddress,
   whitelistState,
   collateral,
   collateralBalance,
@@ -72,6 +73,8 @@ const UserWallet = ({
   openModal
 }) => {
   const { account: address, user, tiers } = useGlobalState();
+
+  const web3Modal = getWeb3Modal(lmsrAddress);
 
   const connect = useCallback(
     provider => {
@@ -207,6 +210,7 @@ const UserWallet = ({
 
 UserWallet.propTypes = {
   // address: PropTypes.string,
+  lmsrAddress: PropTypes.string.isRequired,
   whitelistState: PropTypes.oneOf(WHITELIST_STATES).isRequired,
   collateral: PropTypes.shape({
     fromUnitsMultiplier: PropTypes.object,

--- a/app/src/conf/config.mainnet.json
+++ b/app/src/conf/config.mainnet.json
@@ -1,5 +1,6 @@
 {
   "lmsrAddress": "0x0D0128E6b88ae7FDCD9796b417c2DeAF71F0d8c4",
   "networkId": 1,
-  "network": "mainnet"
+  "network": "mainnet",
+  "infuraApiKey": "d743990732244555a1a0e82d5ab90c7f"
 }

--- a/app/src/conf/config.rinkeby.json
+++ b/app/src/conf/config.rinkeby.json
@@ -1,5 +1,6 @@
 {
   "lmsrAddress": "0x909b8b4459832cd80a8afEc3C22506Fad74011Ca",
   "networkId": 4,
-  "network": "rinkeby"
+  "network": "rinkeby",
+  "infuraApiKey": "d743990732244555a1a0e82d5ab90c7f"
 }

--- a/app/src/utils/web3.js
+++ b/app/src/utils/web3.js
@@ -1,5 +1,7 @@
 import Web3 from "web3";
 
+import conf from "conf";
+
 export const { BN, toBN, soliditySha3, hexToUtf8 } = Web3.utils;
 
 export function getNetworkName(networkId) {
@@ -40,7 +42,7 @@ export function getReadOnlyProviderForNetworkId(networkId) {
     ? networkId == 437894314313
       ? `http://localhost:8545`
       : null
-    : `wss://${providerName}.infura.io/ws/v3/d743990732244555a1a0e82d5ab90c7f`;
+    : `wss://${providerName}.infura.io/ws/v3/` + conf.infuraApiKey;
 }
 
 export async function getAccount(web3) {

--- a/app/src/utils/web3Modal.js
+++ b/app/src/utils/web3Modal.js
@@ -1,0 +1,23 @@
+import Web3Modal from "web3modal";
+import WalletConnectProvider from "@walletconnect/web3-provider";
+
+import conf from "conf";
+
+let web3Modal;
+
+if (!web3Modal) {
+  web3Modal = new Web3Modal({
+    network: conf.network,
+    cacheProvider: true,
+    providerOptions: {
+      walletconnect: {
+        package: WalletConnectProvider,
+        options: {
+          infuraId: conf.infuraApiKey
+        }
+      }
+    }
+  });
+}
+
+export default web3Modal;

--- a/app/src/utils/web3Modal.js
+++ b/app/src/utils/web3Modal.js
@@ -4,20 +4,26 @@ import WalletConnectProvider from "@walletconnect/web3-provider";
 import conf from "conf";
 
 let web3Modal;
+let lmsrAddressCache = null;
 
-if (!web3Modal) {
-  web3Modal = new Web3Modal({
-    network: conf.network,
-    cacheProvider: true,
-    providerOptions: {
-      walletconnect: {
-        package: WalletConnectProvider,
-        options: {
-          infuraId: conf.infuraApiKey
+const getWeb3Modal = lmsrAddress => {
+  if (lmsrAddressCache !== lmsrAddress || !web3Modal) {
+    lmsrAddressCache = lmsrAddress;
+    web3Modal = new Web3Modal({
+      network: conf.network,
+      cacheProvider: true,
+      providerOptions: {
+        walletconnect: {
+          package: WalletConnectProvider,
+          options: {
+            infuraId: conf.infuraApiKey
+          }
         }
       }
-    }
-  });
-}
+    });
+  }
 
-export default web3Modal;
+  return web3Modal;
+};
+
+export default getWeb3Modal;


### PR DESCRIPTION
**Description**

Use web3 cache to keep wallet session between reloads and when switching from market maker.

**To Test**

    Open a new market page
    Connect to a wallet using Metamask or WalletConnect
    Try to reload the page
    Switch market maker address and open another market
    Close the browser and load any of the markets under the same app domain
    In all this cases the session should be remembered
