### PR TITLE
Bugfixes #81: 1st Transaction Modal

### DIFF
--- a/app/src/Modals/Modals.scss
+++ b/app/src/Modals/Modals.scss
@@ -21,6 +21,14 @@
     transition: color .3s ease-in-out;
     text-decoration: none;
 
+    &.disabled {
+      opacity: 0.8;
+      &:focus, &:active, &:hover {
+        cursor: not-allowed;
+        cursor: $shadeBlue;
+      }
+    }
+
     &::after {
       content: $x;
       color: inherit;

--- a/app/src/Modals/Modals.scss
+++ b/app/src/Modals/Modals.scss
@@ -80,9 +80,9 @@
   margin: 0.4rem 1.4rem;
 
   &-label {
-      font-weight: $bold;
-      font-size: 1.8rem;
-      line-height: 1;
-      text-transform: none;
+    font-weight: $bold;
+    font-size: 1.8rem;
+    line-height: 1;
+    text-transform: none;
   }
 }

--- a/app/src/Modals/Transactions/Transaction.js
+++ b/app/src/Modals/Transactions/Transaction.js
@@ -10,8 +10,8 @@ const cx = cn.bind(style);
 
 const NOOP = () => {}
 
-const Transaction = ({ index, name, description, enabled, submitTx }) => {
-  const [pending, setPending] = useState(false);
+const Transaction = ({ index, name, description, enabled, submitTx, setPending, pending }) => {
+  //const [pending, setPending] = useState(false);
   const handleSubmit = useCallback(() => {
     (async () => {
       setPending(true);

--- a/app/src/Modals/Transactions/Transaction.js
+++ b/app/src/Modals/Transactions/Transaction.js
@@ -8,6 +8,8 @@ import Spinner from "components/Spinner";
 
 const cx = cn.bind(style);
 
+const NOOP = () => {}
+
 const Transaction = ({ index, name, description, enabled, submitTx }) => {
   const [pending, setPending] = useState(false);
   const handleSubmit = useCallback(() => {
@@ -31,10 +33,16 @@ const Transaction = ({ index, name, description, enabled, submitTx }) => {
         variant="contained"
         color="primary"
         size="large"
-        disabled={!enabled || pending}
-        onClick={handleSubmit}
+        disabled={!enabled}
+        disableRipple={(!enabled || pending)}
+        onClick={(!enabled || pending) ? NOOP : handleSubmit}
       >
-        {pending ? <Spinner width={12} height={12} /> : "Submit"}
+        {pending ? (
+          <>
+            {/* Avoids button collapse, sorry */}
+            &nbsp;<Spinner width={38} height={38} absolute />
+          </>
+        ) : "Submit"}
       </Button>
     </div>
   );

--- a/app/src/Modals/Transactions/index.js
+++ b/app/src/Modals/Transactions/index.js
@@ -28,9 +28,11 @@ const Transactions = ({ closeModal, title, transactions }) => {
     [currentTxIndex, transactions]
   );
 
+  const [pendingTxIndex, setPendingTxIndex] = useState(null)
+
   return (
     <div className={cx("tx-modal")}>
-      <TitleBar title={title} closeModal={closeModal} />
+      <TitleBar title={title} closeModal={closeModal} disableClose={pendingTxIndex != null} />
       <div className={cx("tx-subheader")}>
         <Account />
         <div className={cx("tx-description")}>
@@ -48,6 +50,8 @@ const Transactions = ({ closeModal, title, transactions }) => {
             enabled={currentTxIndex >= index}
             number={index + 1}
             description={description}
+            setPending={(active) => setPendingTxIndex(active ? index : null)}
+            pending={pendingTxIndex == index}
             submitTx={executeTx}
           />
         ))}

--- a/app/src/Modals/components/upperBar.js
+++ b/app/src/Modals/components/upperBar.js
@@ -5,11 +5,11 @@ import style from "./upperBar.scss";
 
 const cx = cn.bind(style);
 
-const upperBar = ({ title, closeModal }) => {
+const upperBar = ({ title, closeModal, disableClose }) => {
   return (
     <div className={cx("modal-upper", title && "titled")}>
       {title && <span className={cx("title")}>{title}</span>}
-      <span className={cx("modal-close")} onClick={closeModal}></span>{" "}
+      <span className={cx("modal-close", { disabled: disableClose })} onClick={!disableClose && closeModal}></span>{" "}
     </div>
   );
 };

--- a/app/src/components/Spinner.js
+++ b/app/src/components/Spinner.js
@@ -7,7 +7,7 @@ import style from "./spinner.scss";
 
 const cx = cn.bind(style);
 
-const Spinner = ({ centered, inverted, width, height }) => (
+const Spinner = ({ centered, inverted, width, height, absolute }) => (
   <svg
     version="1.1"
     id="loader-1"
@@ -19,7 +19,8 @@ const Spinner = ({ centered, inverted, width, height }) => (
     enableBackground="new 0 0 40 40"
     className={cx("spinner", {
       centered,
-      inverted
+      inverted,
+      absolute
     })}
   >
     <path

--- a/app/src/components/spinner.scss
+++ b/app/src/components/spinner.scss
@@ -10,4 +10,8 @@
       fill: $blue;
     }
   }
+
+  &.absolute {
+    position: absolute;
+  }
 }


### PR DESCRIPTION
# Description
This fixes bugs mentioned by Graeme in the 1st Tx Modal Ticket.

# To Test
- Running a transaction will automatically close the "Pending Transaction" Toast, once completed with Success/Failure
- Fix Modal Buttons according to design (color stays blue even disabled, spinner is correct size)
- Transaction Modal is not closable when a Transaction is pending. This is to avoid confusion

# Code
`Spinner` component now has an `absolute` prop, to determine it's style `position`, for when it needs to be centered via absolute position.
`addToast` now returns a delete function with the toastId already passed. Simply calling this function will immediately discard the created toast and update the list.