### PR TITLE
Handle non zero fee when buying and selling

### DIFF
--- a/app/src/repositories/MarketMakersRepo/MarketMakersRepo.js
+++ b/app/src/repositories/MarketMakersRepo/MarketMakersRepo.js
@@ -47,6 +47,10 @@ export default class MarketMakersRepo {
     return this._lmsrMarketMaker.calcNetCost(outcomeTokenAmounts);
   }
 
+  async calcMarketFee(outcomeTokenNetCost) {
+    return this._lmsrMarketMaker.calcMarketFee(outcomeTokenNetCost);
+  }
+
   async trade(tradeAmounts, collateralLimit, from) {
     return this._lmsrMarketMaker.trade(tradeAmounts, collateralLimit, { from });
   }

--- a/app/src/services/ConditionalTokensService/ConditionalTokensService.js
+++ b/app/src/services/ConditionalTokensService/ConditionalTokensService.js
@@ -309,9 +309,13 @@ export default class ConditionalTokensService {
     }
 
     const tradeAmounts = stagedTradeAmounts.map(amount => amount.toString());
-    const collateralLimit = await this._marketMakersRepo.calcNetCost(
+    const outcomeTokenNetCost = await this._marketMakersRepo.calcNetCost(
       tradeAmounts
     );
+
+    const fee = await this._marketMakersRepo.calcMarketFee(outcomeTokenNetCost);
+
+    const collateralLimit = outcomeTokenNetCost.add(fee);
 
     if (collateral.isWETH && collateralLimit.gt(collateralBalance.amount)) {
       await collateral.contract.deposit({
@@ -350,9 +354,14 @@ export default class ConditionalTokensService {
     }
 
     const tradeAmounts = stagedTradeAmounts.map(amount => amount.toString());
-    const collateralLimit = await this._marketMakersRepo.calcNetCost(
+    const outcomeTokenNetCost = await this._marketMakersRepo.calcNetCost(
       tradeAmounts
     );
+
+    const fee = await this._marketMakersRepo.calcMarketFee(
+      outcomeTokenNetCost.abs()
+    );
+    const collateralLimit = outcomeTokenNetCost.add(fee);
 
     return this._marketMakersRepo.trade(tradeAmounts, collateralLimit, account);
   }


### PR DESCRIPTION
# Description
This PR fix an issue when trading in a market that has a non zero fee. We weren't taking the fee into account when calculating the collateral limit to use in the trade

# Code
This PR will:

- Check the fee amount for the current trade (buy or sell) and add the fee to the collateralLimit

# To Test
- Go to any Sight market with a non zero fee and try to buy and sell tokens.
  - Make sure no reverts happen.
  - For better testing test check received amounts to ensure they match the expected fee
