### PR TITLE
Handle and show fees while user trading

### DIFF
--- a/app/src/Sidebar/components/CategoricalBuy/BuySummary.js
+++ b/app/src/Sidebar/components/CategoricalBuy/BuySummary.js
@@ -15,25 +15,32 @@ const BuySummary = ({
   markets,
   positions,
   collateral,
+  lmsrState,
   stagedTradeAmounts,
-  marketSelections,
   investmentAmount
 }) => {
   const [humanReadablePositions, setHumanReadablePositions] = useState(null);
   const [stagedTradePositionGroups, setStagedTradePositionGroups] = useState(
     []
   );
+  const [fee, setFee] = useState(0);
+
   useEffect(() => {
     setStagedTradePositionGroups(
       stagedTradeAmounts &&
         calcPositionGroups(markets, positions, stagedTradeAmounts)
     );
-  }, [markets, positions, stagedTradeAmounts]);
+
+    if (lmsrState) {
+      setFee(lmsrState.fee * 100);
+    }
+  }, [markets, positions, stagedTradeAmounts, lmsrState]);
 
   useEffect(() => {
     let humanReadablePositions = {
       payOutWhen: {
         title: "ROI if markets resolves to selected outcome:",
+        feeTitle: "Of which fees (" + fee + "%):",
         positions: []
       },
       loseInvestmentWhen: {
@@ -45,13 +52,19 @@ const BuySummary = ({
     (stagedTradePositionGroups || []).forEach(
       ({ outcomeSet, runningAmount }) => {
         let hasEnteredInvestment;
+        let investMentFee;
 
         try {
           const decimalInvest = Decimal(investmentAmount);
           hasEnteredInvestment = decimalInvest.gt(0);
+          investMentFee = decimalInvest.mul(lmsrState.fee);
         } catch (err) {
           //
         }
+
+        humanReadablePositions.payOutWhen.fee = investmentAmount
+          ? investMentFee
+          : 0;
 
         // all payouts
         humanReadablePositions.payOutWhen.positions = outcomeSet;
@@ -113,6 +126,20 @@ const BuySummary = ({
           .filter(category => category && category.positions.length)
           .map(category => (
             <Fragment key={category.title}>
+              {category.fee !== undefined && (
+                <>
+                  <div className={cx("summary-heading")}>
+                    {category.feeTitle}
+                  </div>
+                  <div className={cx("summary-category")}>
+                    <div className={cx("category-values")}>
+                      <p className={cx("category-value", "value")}>
+                        {category.fee.toString()}
+                      </p>
+                    </div>
+                  </div>
+                </>
+              )}
               <div className={cx("summary-heading")}>{category.title}</div>
               <div className={cx("summary-category")}>
                 <div className={cx("category-values")}>
@@ -170,12 +197,15 @@ BuySummary.propTypes = {
     decimals: PropTypes.number.isRequired,
     isWETH: PropTypes.bool.isRequired
   }).isRequired,
-  marketSelections: PropTypes.arrayOf(
-    PropTypes.shape({
-      isAssumed: PropTypes.bool.isRequired,
-      selectedOutcomeIndex: PropTypes.number
-    }).isRequired
-  ),
+  lmsrState: PropTypes.shape({
+    fee: PropTypes.string
+  }).isRequired,
+  // marketSelections: PropTypes.arrayOf(
+  //   PropTypes.shape({
+  //     isAssumed: PropTypes.bool.isRequired,
+  //     selectedOutcomeIndex: PropTypes.number
+  //   }).isRequired
+  // ),
   stagedTradeAmounts: PropTypes.arrayOf(
     PropTypes.instanceOf(Decimal).isRequired
   ),

--- a/app/src/Sidebar/components/CategoricalBuy/BuySummary.js
+++ b/app/src/Sidebar/components/CategoricalBuy/BuySummary.js
@@ -52,18 +52,18 @@ const BuySummary = ({
     (stagedTradePositionGroups || []).forEach(
       ({ outcomeSet, runningAmount }) => {
         let hasEnteredInvestment;
-        let investMentFee;
+        let investmentFee;
 
         try {
           const decimalInvest = Decimal(investmentAmount);
           hasEnteredInvestment = decimalInvest.gt(0);
-          investMentFee = decimalInvest.mul(lmsrState.fee);
+          investmentFee = decimalInvest.mul(lmsrState.fee);
         } catch (err) {
           //
         }
 
         humanReadablePositions.payOutWhen.fee = investmentAmount
-          ? investMentFee
+          ? investmentFee
           : 0;
 
         // all payouts

--- a/app/src/Sidebar/components/CategoricalBuy/index.js
+++ b/app/src/Sidebar/components/CategoricalBuy/index.js
@@ -88,9 +88,9 @@ const Buy = ({
       );
 
       // We have to substract the fee
-      const investmentAmountInUnitsAfterFee = investmentAmountInUnits.mul(
-        1 - lmsrState.fee
-      );
+      const investmentAmountInUnitsAfterFee = investmentAmountInUnits.div(
+        Decimal(1).add(lmsrState.fee)
+      ).toDecimalPlaces(0);
 
       if (!investmentAmountInUnitsAfterFee.isInteger())
         throw new Error(

--- a/app/src/Sidebar/components/CategoricalBuy/index.js
+++ b/app/src/Sidebar/components/CategoricalBuy/index.js
@@ -88,9 +88,9 @@ const Buy = ({
       );
 
       // We have to substract the fee
-      const investmentAmountInUnitsAfterFee = investmentAmountInUnits.div(
-        Decimal(1).add(lmsrState.fee)
-      ).toDecimalPlaces(0);
+      const investmentAmountInUnitsAfterFee = investmentAmountInUnits
+        .div(Decimal(1).add(lmsrState.fee))
+        .toDecimalPlaces(0);
 
       if (!investmentAmountInUnitsAfterFee.isInteger())
         throw new Error(

--- a/app/src/Sidebar/components/CategoricalBuy/index.js
+++ b/app/src/Sidebar/components/CategoricalBuy/index.js
@@ -87,7 +87,12 @@ const Buy = ({
         hasEnteredInvestment ? investmentAmount : zeroDecimal
       );
 
-      if (!investmentAmountInUnits.isInteger())
+      // We have to substract the fee
+      const investmentAmountInUnitsAfterFee = investmentAmountInUnits.mul(
+        1 - lmsrState.fee
+      );
+
+      if (!investmentAmountInUnitsAfterFee.isInteger())
         throw new Error(
           `Got more than ${collateral.decimals} decimals in value ${investmentAmount}`
         );
@@ -96,7 +101,7 @@ const Buy = ({
         calcOutcomeTokenCounts(
           positions,
           lmsrState,
-          investmentAmountInUnits,
+          investmentAmountInUnitsAfterFee,
           marketSelections
         )
       );
@@ -155,7 +160,6 @@ const Buy = ({
         precheck: async () => {
           return conditionalTokensService.needsMoreAllowance({
             investmentAmount,
-            stagedTradeAmounts,
             account,
             collateralBalance
           });
@@ -305,8 +309,8 @@ const Buy = ({
             markets,
             positions,
             collateral,
+            lmsrState,
             stagedTradeAmounts,
-            marketSelections,
             investmentAmount
           }}
         />

--- a/app/src/Sidebar/components/ScalarBuy/index.js
+++ b/app/src/Sidebar/components/ScalarBuy/index.js
@@ -85,7 +85,12 @@ const Buy = ({
         hasEnteredInvestment ? investmentAmount : zeroDecimal
       );
 
-      if (!investmentAmountInUnits.isInteger())
+      // We have to substract the fee
+      const investmentAmountInUnitsAfterFee = investmentAmountInUnits.mul(
+        1 - lmsrState.fee
+      );
+
+      if (!investmentAmountInUnitsAfterFee.isInteger())
         throw new Error(
           `Got more than ${collateral.decimals} decimals in value ${investmentAmount}`
         );
@@ -94,7 +99,7 @@ const Buy = ({
         calcOutcomeTokenCounts(
           positions,
           lmsrState,
-          investmentAmountInUnits,
+          investmentAmountInUnitsAfterFee,
           marketSelections
         )
       );

--- a/app/src/Sidebar/components/ScalarBuy/index.js
+++ b/app/src/Sidebar/components/ScalarBuy/index.js
@@ -86,9 +86,9 @@ const Buy = ({
       );
 
       // We have to substract the fee
-      const investmentAmountInUnitsAfterFee = investmentAmountInUnits.mul(
-        1 - lmsrState.fee
-      );
+      const investmentAmountInUnitsAfterFee = investmentAmountInUnits
+        .div(Decimal(1).add(lmsrState.fee))
+        .toDecimalPlaces(0);
 
       if (!investmentAmountInUnitsAfterFee.isInteger())
         throw new Error(
@@ -332,6 +332,7 @@ const Buy = ({
               investmentAmount,
               collateral
             }}
+            fee={lmsrState.fee}
           ></ProfitSimulator>
         )}
         <div className={cx("invest-ctrls")}>
@@ -398,7 +399,8 @@ Buy.propTypes = {
     funding: PropTypes.instanceOf(BN).isRequired,
     positionBalances: PropTypes.arrayOf(PropTypes.instanceOf(BN).isRequired)
       .isRequired,
-    stage: PropTypes.string.isRequired
+    stage: PropTypes.string.isRequired,
+    fee: PropTypes.string.isRequired
   }),
   marketSelections: PropTypes.arrayOf(
     PropTypes.shape({

--- a/app/src/Sidebar/components/ScalarBuy/profitSimulator.js
+++ b/app/src/Sidebar/components/ScalarBuy/profitSimulator.js
@@ -19,7 +19,8 @@ const profitSimulator = ({
   stagedTradeAmounts,
   marketSelection,
   investmentAmount,
-  collateral
+  collateral,
+  fee
 }) => {
   const [profitSim, setProfitSim] = useState({
     value: 0,
@@ -65,6 +66,11 @@ const profitSimulator = ({
         hasEnteredInvestment ? investmentAmount : zeroDecimal
       );
 
+      // We have to substract the fee
+      const investmentAmountInUnitsAfterFee = investmentAmountInUnits
+        .div(Decimal(1).add(fee))
+        .toDecimalPlaces(0);
+
       const normalizedSlider = new Decimal(sliderValue)
         .sub(decimalLower)
         .div(decimalUpper.sub(decimalLower));
@@ -80,7 +86,7 @@ const profitSimulator = ({
       setProfitSim({
         maxPayout: maxPayout.toString(),
         minPayout: "0",
-        fee: investmentAmountInUnits.mul(0.05).toString(),
+        fee: investmentAmountInUnits.mul(fee).toString(),
         cost: investmentAmountInUnits.toString(),
         value: profitAmount.toString(),
         percent: investmentAmountInUnits.gt(0)
@@ -160,13 +166,13 @@ const profitSimulator = ({
               {formatCollateral(profitSim.cost, collateral)}
             </span>
           </div>
-          {/*<div className={cx("row")}>
-            <span className={cx("label")}>Fees (0.5%)</span>
+          <div className={cx("row")}>
+            <span className={cx("label")}>Fees ({fee * 100}%)</span>
             <span className={cx("spacer")} />
             <span className={cx("value")}>
               {formatCollateral(profitSim.fee, collateral)}
             </span>
-          </div>*/}
+          </div>
         </div>
       </div>
     </>
@@ -199,7 +205,8 @@ profitSimulator.propTypes = {
   }).isRequired,
   stagedTradeAmounts: PropTypes.arrayOf(
     PropTypes.instanceOf(Decimal).isRequired
-  )
+  ),
+  fee: PropTypes.string.isRequired
 };
 
 export default profitSimulator;

--- a/app/src/Sidebar/components/Sell/SellForm.js
+++ b/app/src/Sidebar/components/Sell/SellForm.js
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useState } from "react";
+import PropTypes from "prop-types";
 import Decimal from "decimal.js-light";
 import Select from "react-select";
 import Web3 from "web3";
@@ -24,15 +25,16 @@ const SellForm = ({
   currentSellingPosition,
   onCancelSell,
   positions,
+  positionBalances,
   ongoingTransactionType,
   setStagedTransactionType,
   setStagedTradeAmounts,
   conditionalTokensService,
-  positionBalances,
   sellOutcomeTokens,
   onOutcomeChange,
   positionGroups,
-  asWrappedTransaction
+  asWrappedTransaction,
+  fee
 }) => {
   const { collateral } = useGlobalState();
 
@@ -67,9 +69,11 @@ const SellForm = ({
   );
 
   useEffect(() => {
-    const findIndex = positionGroups.findIndex(({ outcomeSet: [{ outcomeIndex }] }) => {
-      return outcomeIndex === selectedOutcomeIndex;
-    });
+    const findIndex = positionGroups.findIndex(
+      ({ outcomeSet: [{ outcomeIndex }] }) => {
+        return outcomeIndex === selectedOutcomeIndex;
+      }
+    );
 
     setSelectOutcomeValue(findIndex);
   }, [currentSellingPosition, availableOutcomes]);
@@ -256,6 +260,30 @@ const SellForm = ({
           </div>
         </div>
         <div className={cx("sell-form-row")}>
+          <label>Fee ({fee * 100}%)</label>
+          <div className={cx("entry")}>
+            <div className={cx("input-group")}>
+              <input
+                type="text"
+                readOnly
+                value={
+                  estimatedSaleEarning
+                    ? new Decimal(estimatedSaleEarning)
+                        .div(Math.pow(10, collateral.decimals))
+                        .toSignificantDigits(collateralSignificantDigits)
+                        .mul(fee)
+                        .toString()
+                    : "..."
+                }
+                className={cx("input")}
+              />
+              <span className={cx("input-append", "collateral-name")}>
+                <abbr title={collateral.name}>{collateral.symbol}</abbr>
+              </span>
+            </div>
+          </div>
+        </div>
+        <div className={cx("sell-form-row")}>
           <label></label>
           <div className={cx("entry")}>
             <button
@@ -279,6 +307,26 @@ const SellForm = ({
       </div>
     </div>
   );
+};
+
+SellForm.propTypes = {
+  onCancelSell: PropTypes.func.isRequired,
+  positions: PropTypes.arrayOf(
+    PropTypes.shape({
+      positionIndex: PropTypes.number.isRequired,
+      outcomes: PropTypes.arrayOf(
+        PropTypes.shape({
+          marketIndex: PropTypes.number.isRequired,
+          outcomeIndex: PropTypes.number.isRequired
+        }).isRequired
+      ).isRequired
+    }).isRequired
+  ).isRequired,
+  ongoingTransactionType: PropTypes.string,
+  setStagedTransactionType: PropTypes.func.isRequired,
+  setStagedTradeAmounts: PropTypes.func.isRequired,
+  asWrappedTransaction: PropTypes.func.isRequired,
+  fee: PropTypes.string.isRequired
 };
 
 export default SellForm;

--- a/app/src/Sidebar/components/Sell/index.js
+++ b/app/src/Sidebar/components/Sell/index.js
@@ -1,5 +1,7 @@
 import React, { useState, useEffect, useCallback } from "react";
 import PropTypes from "prop-types";
+import Decimal from "decimal.js-light";
+
 import Web3 from "web3";
 import { calcPositionGroups } from "utils/position-groups";
 import { getMarketProbabilities } from "utils/probabilities";
@@ -168,7 +170,6 @@ const SellOrPositions = ({
 
   return isSelling ? (
     <Sell
-      markets={markets}
       currentSellingPosition={currentSellingPosition}
       onCancelSell={clearAllPositions}
       positions={positions}
@@ -182,6 +183,7 @@ const SellOrPositions = ({
       asWrappedTransaction={asWrappedTransaction}
       ongoingTransactionType={ongoingTransactionType}
       positionGroups={positionGroups}
+      fee={lmsrState.fee}
     />
   ) : (
     <Positions
@@ -219,8 +221,23 @@ SellOrPositions.propTypes = {
     marketMakerAddress: PropTypes.string.isRequired,
     funding: PropTypes.instanceOf(BN).isRequired,
     positionBalances: PropTypes.arrayOf(PropTypes.instanceOf(BN).isRequired)
-      .isRequired
-  })
+      .isRequired,
+    fee: PropTypes.string.isRequired
+  }),
+  marketSelections: PropTypes.arrayOf(
+    PropTypes.shape({
+      isAssumed: PropTypes.bool.isRequired,
+      selectedOutcomeIndex: PropTypes.number
+    }).isRequired
+  ),
+  stagedTradeAmounts: PropTypes.arrayOf(
+    PropTypes.instanceOf(Decimal).isRequired
+  ),
+  setStagedTradeAmounts: PropTypes.func.isRequired,
+  stagedTransactionType: PropTypes.string,
+  setStagedTransactionType: PropTypes.func.isRequired,
+  ongoingTransactionType: PropTypes.string,
+  asWrappedTransaction: PropTypes.func.isRequired
 };
 
 export default SellOrPositions;

--- a/app/src/services/ConditionalTokensService/ConditionalTokensService.js
+++ b/app/src/services/ConditionalTokensService/ConditionalTokensService.js
@@ -161,6 +161,8 @@ export default class ConditionalTokensService {
   }
 
   async needsMoreAllowance({ investmentAmount, account, collateralBalance }) {
+    // This function doesn't depend on fees. We check allowance for the full amount
+    // Fee is included in invesmentAmount
     const collateral = await this._marketMakersRepo.getCollateralToken();
 
     const tierLimitStatus = await this.isTierLimitExceeded({
@@ -216,6 +218,8 @@ export default class ConditionalTokensService {
     account,
     collateralBalance
   }) {
+    // This function doesn't depend on fees. We check allowance for the full amount
+    // Fee is included in invesmentAmount
     if (stagedTradeAmounts == null)
       throw new ToastifyError(`No buy amount set yet`);
 
@@ -314,8 +318,11 @@ export default class ConditionalTokensService {
     );
 
     const fee = await this._marketMakersRepo.calcMarketFee(outcomeTokenNetCost);
+    console.log("Service Fee: ", fee.toString());
 
     const collateralLimit = outcomeTokenNetCost.add(fee);
+    console.log("Collateral limit with fee: ", collateralLimit.toString());
+    console.log("OutcomeTokenNetCost: ", outcomeTokenNetCost.toString());
 
     if (collateral.isWETH && collateralLimit.gt(collateralBalance.amount)) {
       await collateral.contract.deposit({

--- a/app/src/services/ConditionalTokensService/ConditionalTokensService.js
+++ b/app/src/services/ConditionalTokensService/ConditionalTokensService.js
@@ -318,11 +318,7 @@ export default class ConditionalTokensService {
     );
 
     const fee = await this._marketMakersRepo.calcMarketFee(outcomeTokenNetCost);
-    console.log("Service Fee: ", fee.toString());
-
     const collateralLimit = outcomeTokenNetCost.add(fee);
-    console.log("Collateral limit with fee: ", collateralLimit.toString());
-    console.log("OutcomeTokenNetCost: ", outcomeTokenNetCost.toString());
 
     if (collateral.isWETH && collateralLimit.gt(collateralBalance.amount)) {
       await collateral.contract.deposit({


### PR DESCRIPTION
# Description
This PR will add fee messages and all the calculations to show user how much a trade will cost and how many earnings could receive

# Code
This PR will:

- Use the fee in the market maker to calculate how much will cost a trade to an user (excluding gas costs)

# To Test
- Go to any Sight market with a non zero fee and try to buy and sell tokens.
  - Make sure no reverts happen.
  - For better testing test check received amounts to ensure they match the expected fee

Categorical market with 10% fee: `0x31B1023e3d9b3b88873D38B0a7eB482d3F51105E`
Scalar market with 10% fee: `0xA851BBDA5413D206E80f7A7DDd79352Fa8F87C11`
