### PR TITLE
Fix #80: Labels on SOW Forms

### DIFF
--- a/app/src/Modals/KYC/steps/SOW.js
+++ b/app/src/Modals/KYC/steps/SOW.js
@@ -168,9 +168,10 @@ const SourceOfWealth = ({ closeModal }) => {
             const showEmployerJobField = values.mainSource === "salaried";
             const showSelfEmployedJobField =
               values.mainSource === "self-employed";
-            const showSpecificsField = !DO_NOT_REQUIRE_SPECIFICS.includes(
-              values.mainSource
-            );
+            
+            const showSpecificsField =
+              values.mainSource !== undefined &&
+              !DO_NOT_REQUIRE_SPECIFICS.includes(values.mainSource);
 
             if (submitting) {
               return <Spinner inverted />;
@@ -194,7 +195,7 @@ const SourceOfWealth = ({ closeModal }) => {
                   component={Select}
                   name="mainSource"
                   options={SOURCE_OF_WEALTH_OPTIONS}
-                  label="What is your main source of funds?"
+                  label="Please select source of funds"
                 />
                 {showCompanyNameField && (
                   <Field

--- a/app/src/views/kyc/Sow.js
+++ b/app/src/views/kyc/Sow.js
@@ -179,7 +179,7 @@ const Sow = props => {
 
           <span>
             <strong>
-              What is your main source of funds?{" "}
+              Please select source of funds{" "}
               <small className={cx("text-red")}>*</small>
             </strong>
             <select

--- a/app/src/views/kyc/tier2/steps/SourceOfWealth.js
+++ b/app/src/views/kyc/tier2/steps/SourceOfWealth.js
@@ -145,9 +145,9 @@ const SourceOfWealth = ({ email, account, handleAdvanceStep }) => {
             const showEmployerJobField = values.mainSource === "salaried";
             const showSelfEmployedJobField =
               values.mainSource === "self-employed";
-            const showSpecificsField = !DOES_NOT_REQUIRE_SPECIFICS.includes(
-              values.mainSource
-            );
+            const showSpecificsField =
+              values.mainSource !== undefined &&
+              !DOES_NOT_REQUIRE_SPECIFICS.includes(values.mainSource);
 
             if (submitting) {
               return <Spinner inverted />;
@@ -166,7 +166,7 @@ const SourceOfWealth = ({ email, account, handleAdvanceStep }) => {
                   component={Select}
                   name="mainSource"
                   options={SOURCE_OF_WEALTH_OPTIONS}
-                  label="What is your main source of funds?"
+                  label="Please select source of funds"
                 />
                 {showCompanyNameField && (
                   <Field


### PR DESCRIPTION
# Description
Fixes a label issue on Source of Wealth forms. Also makes an input hidden when no selection was made on source of wealth.

# To Test:
- See "What is your main source of wealth?" was changed to "Please select source of funds"
- See "Please add specifics to your source of funds" is not showing without a selection made.

# Code:
/