### PR TITLE
Bug/Feature #109: UX improvements KYC Flow

### DIFF
--- a/app/src/Modals/KYC/index.js
+++ b/app/src/Modals/KYC/index.js
@@ -8,6 +8,7 @@ import style from "./kyc.scss";
 const cx = cn.bind(style);
 
 export const STEP_RESIDENCE = "RESIDENCE";
+export const STEP_INFO = "INFO";
 export const STEP_TIER2_REQUEST = "TIER2_REQUEST";
 export const STEP_TIER2_REQUEST_SUCCESS = "TIER2_REQUEST_SUCCESS";
 export const STEP_TIER3_REQUEST_SUCCESS = "TIER3_REQUEST_SUCCESS";
@@ -20,6 +21,7 @@ export const STEP_SOW = "SOW";
 
 // Child components loaded lazily on KYC load
 const STEP_COMPONENTS = {
+  [STEP_INFO]: () => import("./steps/Info"),
   [STEP_RESIDENCE]: () => import("./steps/EuropeResident"),
   [STEP_TIER2_REQUEST]: () => import("./steps/Tier2Request"),
   [STEP_TIER2_REQUEST_SUCCESS]: () => import("./steps/Tier2RequestSuccess"),
@@ -37,7 +39,7 @@ const KYC = ({ closeModal, initialStep, ...props }) => {
   const [loading, setLoading] = useState("LOADING");
 
   const [person, setPerson] = useState({});
-  const [currentStepIndex, setCurrentStepIndex] = useState(STEP_RESIDENCE);
+  const [currentStepIndex, setCurrentStepIndex] = useState(STEP_INFO);
   const [currentStepProps, setCurrentStepProps] = useState(props);
 
   useEffect(() => {

--- a/app/src/Modals/KYC/kyc.scss
+++ b/app/src/Modals/KYC/kyc.scss
@@ -181,6 +181,55 @@
 
 }
 
+.tier-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 1.4rem;
+
+  thead {
+    background-color: #00193c;
+    color: white;
+    text-align: left;
+    
+    th {
+      padding: 1rem 1rem;
+    }
+  }
+
+  tbody {
+    td {
+      padding: 1rem 1rem;
+    }
+
+    tr {
+      background-color: white;
+      &:nth-child(odd) {
+        background-color: #f2fafb
+      }
+
+      border-bottom: 1px solid gray;
+    }
+  }
+
+  ul {
+    text-align: left;
+  }
+}
+
+.full-width {
+  width: 100%;
+  max-width: 900px;
+}
+
+.tier-intro {
+  max-width: 600px;
+  text-align: center;
+  margin: 1rem auto 2rem auto;
+
+  font-size: 1.6rem;
+  line-height: 2.4rem;
+}
+
 @keyframes animate-rotate {
   0% { transform: rotate(0deg);  }
   50% { transform: rotate(359deg); }

--- a/app/src/Modals/KYC/steps/EuropeResident.js
+++ b/app/src/Modals/KYC/steps/EuropeResident.js
@@ -7,7 +7,7 @@ import style from "../kyc.scss";
 
 import UpperBar from "../../components/upperBar";
 
-import { STEP_TIER2_REQUEST, STEP_NATIONALITY } from "../";
+import { STEP_NATIONALITY } from "../";
 
 const cx = classnames.bind(style);
 
@@ -39,7 +39,7 @@ const Residence = ({ closeModal, handleAdvanceStep }) => {
             size="large"
             onClick={() =>
               handleAdvanceStep([
-                STEP_TIER2_REQUEST,
+                STEP_NATIONALITY,
                 {
                   nonEuResident: true
                 }

--- a/app/src/Modals/KYC/steps/Info.js
+++ b/app/src/Modals/KYC/steps/Info.js
@@ -1,0 +1,97 @@
+import React from "react";
+import PropTypes from "prop-types";
+import classnames from "classnames/bind";
+import Button from "@material-ui/core/Button";
+
+import style from "../kyc.scss";
+
+import UpperBar from "../../components/upperBar";
+
+import { STEP_RESIDENCE } from "../";
+
+const cx = classnames.bind(style);
+
+const Info = ({ closeModal, handleAdvanceStep }) => {
+  return (
+    <>
+      <UpperBar closeModal={closeModal} title="Create Account"></UpperBar>
+      <div className={cx("modal-body", "full-width")}>
+        <p className={cx("field", "tier-intro")}>
+          By providing us with some basic information you can start buying
+          positions with your connected wallet. The higher your tier level is,
+          the higher the amounts are you can trade with on Sight&apos;s
+          prediction markets.
+        </p>
+        <table className={cx("tier-table")}>
+          <thead>
+            <tr>
+              <th>Tier</th>
+              <th>Annual Buy Limit</th>
+              <th>Requirements</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Tier 1</td>
+              <td>$150</td>
+              <td>
+                <ul>
+                  <li>Full name</li>
+                  <li>Date of birth</li>
+                  <li>Country of residence</li>
+                  <li>Phone number</li>
+                </ul>
+              </td>
+              <td>Not submitted</td>
+            </tr>
+            <tr>
+              <td>Tier 2</td>
+              <td>$15.000</td>
+              <td>
+                <ul>
+                  <li>All of the above</li>
+                  <li>Government issued ID</li>
+                  <li>Proof of residence</li>
+                  <li>Selfie</li>
+                  <li>Source of funds</li>
+                </ul>
+              </td>
+              <td>Not submitted</td>
+            </tr>
+            <tr>
+              <td>Tier 3</td>
+              <td>Unlimited</td>
+              <td>
+                <ul>
+                  <li>All of the above</li>
+                  <li>Verification of source of funds</li>
+                </ul>
+              </td>
+              <td>Not submitted</td>
+            </tr>
+          </tbody>
+        </table>
+        <div className={cx("modal-buttons")}>
+          <Button
+            className={cx("material-button")}
+            classes={{ label: cx("material-button-label") }}
+            variant="contained"
+            color="primary"
+            size="large"
+            onClick={() => handleAdvanceStep(STEP_RESIDENCE)}
+          >
+            Get Verified
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+};
+
+Info.propTypes = {
+  closeModal: PropTypes.func.isRequired,
+  handleAdvanceStep: PropTypes.func.isRequired
+};
+
+export default Info;

--- a/app/src/Modals/KYC/steps/Info.js
+++ b/app/src/Modals/KYC/steps/Info.js
@@ -11,7 +11,8 @@ import { STEP_RESIDENCE } from "../";
 
 const cx = classnames.bind(style);
 
-const Info = ({ closeModal, handleAdvanceStep }) => {
+const Info = ({ closeModal, handleAdvanceStep, tier }) => {
+  console.log(tier)
   return (
     <>
       <UpperBar closeModal={closeModal} title="Create Account"></UpperBar>
@@ -43,7 +44,7 @@ const Info = ({ closeModal, handleAdvanceStep }) => {
                   <li>Phone number</li>
                 </ul>
               </td>
-              <td>Not submitted</td>
+              <td>{tier >= 1 ? "Submitted" : "Not submitted"}</td>
             </tr>
             <tr>
               <td>Tier 2</td>
@@ -57,7 +58,7 @@ const Info = ({ closeModal, handleAdvanceStep }) => {
                   <li>Source of funds</li>
                 </ul>
               </td>
-              <td>Not submitted</td>
+              <td>{tier >= 2 ? "Submitted" : "Not submitted"}</td>
             </tr>
             <tr>
               <td>Tier 3</td>
@@ -68,7 +69,7 @@ const Info = ({ closeModal, handleAdvanceStep }) => {
                   <li>Verification of source of funds</li>
                 </ul>
               </td>
-              <td>Not submitted</td>
+              <td>{tier >= 3 ? "Submitted" : "Not submitted"}</td>
             </tr>
           </tbody>
         </table>

--- a/app/src/Modals/KYC/steps/Nationality.js
+++ b/app/src/Modals/KYC/steps/Nationality.js
@@ -12,7 +12,7 @@ import UpperBar from "../../components/upperBar";
 
 import { getResidenceCountries } from "api/onboarding";
 
-import { STEP_REJECTED, STEP_PERSONAL } from "../";
+import { STEP_REJECTED, STEP_PERSONAL, STEP_TIER2_REQUEST } from "../";
 import { isRequired, validator } from "utils/validations";
 
 const cx = classnames.bind(style);
@@ -21,7 +21,12 @@ const FIELDS = {
   nationality: isRequired
 };
 
-const Nationality = ({ closeModal, updatePerson, handleAdvanceStep }) => {
+const Nationality = ({
+  closeModal,
+  updatePerson,
+  handleAdvanceStep,
+  nonEuResident
+}) => {
   const [countries, setCountries] = useState();
   const [loadingState, setIsLoading] = useState("PENDING");
 
@@ -39,18 +44,22 @@ const Nationality = ({ closeModal, updatePerson, handleAdvanceStep }) => {
     }
   }, []);
 
-  const onSubmit = useCallback(values => {
-    updatePerson(prevValues => ({
-      ...prevValues,
-      countryNationalityIso2: values.nationality.iso2
-    }));
+  const onSubmit = useCallback(
+    values => {
+      updatePerson(prevValues => ({
+        ...prevValues,
+        countryNationalityIso2: values.nationality.iso2
+      }));
 
-    handleAdvanceStep(
-      values.nationality.canSdd
-        ? STEP_PERSONAL
-        : [STEP_REJECTED, { reason: "nationality" }]
-    );
-  }, []);
+      const nextStep = nonEuResident ? STEP_TIER2_REQUEST : STEP_PERSONAL;
+      handleAdvanceStep(
+        values.nationality.canSdd
+          ? nextStep
+          : [STEP_REJECTED, { reason: "nationality" }]
+      );
+    },
+    [nonEuResident, handleAdvanceStep, updatePerson]
+  );
 
   useEffect(() => {
     fetchCountries();
@@ -128,7 +137,12 @@ const Nationality = ({ closeModal, updatePerson, handleAdvanceStep }) => {
 Nationality.propTypes = {
   closeModal: PropTypes.func.isRequired,
   handleAdvanceStep: PropTypes.func.isRequired,
-  updatePerson: PropTypes.func.isRequired
+  updatePerson: PropTypes.func.isRequired,
+  nonEuResident: PropTypes.bool
+};
+
+Nationality.defaultProps = {
+  nonEuResident: false
 };
 
 export default Nationality;

--- a/app/src/Root/index.js
+++ b/app/src/Root/index.js
@@ -16,7 +16,8 @@ import ToastifyError from "utils/ToastifyError";
 import getWeb3Modal from "utils/web3Modal";
 import {
   isCurrentUserUpgrading,
-  isCurrentUserActionRequired
+  isCurrentUserActionRequired,
+  getCurrentUserTierData,
 } from "utils/tiers";
 //import { Notifications as NotificationIcon } from "@material-ui/icons";
 
@@ -384,7 +385,8 @@ const RootComponent = ({
         return false;
       } else if (ONBOARDING_MODE === "TIERED") {
         // If mode is Tiered we have to open SDD KYC Modal
-        openModal("KYC");
+        const { name } = getCurrentUserTierData(tiers, user);
+        openModal("KYC", { tier: name });
         return false;
       } else {
         // Future-proofing: default error handling shows an error indicating

--- a/app/src/Root/index.js
+++ b/app/src/Root/index.js
@@ -18,8 +18,7 @@ import {
   getCurrentUserTierData,
   isAccountCreationProcessing,
   isCurrentUserUpgrading,
-  isCurrentUserActionRequired,
-  getCurrentUserTierData,
+  isCurrentUserActionRequired
 } from "utils/tiers";
 //import { Notifications as NotificationIcon } from "@material-ui/icons";
 


### PR DESCRIPTION
# Background
To improve the UX flow of the KYC process these changes were made. 
- New Modal giving an overviews of tiers (as well as currently obtained tiers)
- Non-EU Residence must now enter their nationality, so users can be informed that their nationality does not allow them to trade on the interface before entering their e-mail. 

# To Test
- On a new unwhitelisted account,
  - open a KYC modal and notice the new “info screen”
  - verify tiers match your account
  - should not open when opening kyc from an e-mail link
- As an EU-resident, the flow should be the same (Welcome > EU-Resident > Nationality > Personal Details)
- As a non EU-resident, the flow for a nationality allowed for SDD (Welcome > EU-Resident (No) > Nationality (SSD Nationality) > Step 2 Details)
- As a non EU-resident, the flow for a nationality not allowed for SDD (Welcome > EU-Resident (No) > Nationality (non SDD Nationality) > Denied)

# Code
To display the submitted tiers, I’ve used the utils functions from utils/tiers.js
New Modal is now the default start and is named “INFO”