### PR TITLE
Feature/#110 display outcome tokens buy form

### DIFF
--- a/app/src/Sidebar/components/CategoricalBuy/BuySummary.js
+++ b/app/src/Sidebar/components/CategoricalBuy/BuySummary.js
@@ -39,8 +39,9 @@ const BuySummary = ({
   useEffect(() => {
     let humanReadablePositions = {
       payOutWhen: {
-        title: "ROI if markets resolves to selected outcome:",
-        feeTitle: "Of which fees (" + fee + "%):",
+        tokenAmountTitle: "Outcome tokens",
+        title: "ROI if winning outcome",
+        feeTitle: "Of which fees (" + fee + "%)",
         positions: []
       },
       loseInvestmentWhen: {
@@ -50,7 +51,7 @@ const BuySummary = ({
     };
 
     (stagedTradePositionGroups || []).forEach(
-      ({ outcomeSet, runningAmount }) => {
+      ({ outcomeSet, runningAmount, amount }) => {
         let hasEnteredInvestment;
         let investmentFee;
 
@@ -68,9 +69,14 @@ const BuySummary = ({
 
         // all payouts
         humanReadablePositions.payOutWhen.positions = outcomeSet;
+        humanReadablePositions.payOutWhen.tokenAmount = hasEnteredInvestment
+          ? amount
+          : zeroDecimal;
+
         humanReadablePositions.payOutWhen.runningAmount = hasEnteredInvestment
           ? runningAmount
           : zeroDecimal;
+
         humanReadablePositions.payOutWhen.increment = hasEnteredInvestment
           ? collateral.fromUnitsMultiplier.mul(runningAmount.toString())
               .sub(investmentAmount)
@@ -127,36 +133,42 @@ const BuySummary = ({
           .map(category => (
             <Fragment key={category.title}>
               {category.fee !== undefined && (
-                <>
-                  <div className={cx("summary-heading")}>
-                    {category.feeTitle}
-                  </div>
-                  <div className={cx("summary-category")}>
-                    <div className={cx("category-values")}>
-                      <p className={cx("category-value", "value")}>
-                        {category.fee.toString()}
-                      </p>
-                    </div>
-                  </div>
-                </>
-              )}
-              <div className={cx("summary-heading")}>{category.title}</div>
-              <div className={cx("summary-category")}>
-                <div className={cx("category-values")}>
-                  <p className={cx("category-value", "value")}>
-                    {formatCollateral(category.runningAmount, collateral)}
-                    {category.increment && category.increment.abs().gt(0.01) && (
-                      <span
-                        className={cx("change-percentage", {
-                          negative: category.increment.lt(0)
-                        })}
-                      >
-                        {" "}
-                        {category.increment.toString()}%
-                      </span>
-                    )}
-                  </p>
+                <div className={cx("summary-element")}>
+                  <span>{category.feeTitle}</span>
+                  <span className={cx("dotted-separator")}></span>
+                  <span className={cx("summary-element-value")}>
+                    {category.fee.toString()} {collateral.symbol}
+                  </span>
                 </div>
+              )}
+              {category.tokenAmount !== undefined && (
+                <div className={cx("summary-element")}>
+                  <span>{category.tokenAmountTitle}</span>
+                  <span className={cx("dotted-separator")}></span>
+                  <span className={cx("summary-element-value")}>
+                    {new Decimal(category.tokenAmount.toString())
+                      .div(1e18)
+                      .toSignificantDigits(4)
+                      .toString()}
+                  </span>
+                </div>
+              )}
+              <div className={cx("summary-element")}>
+                <span>{category.title}</span>
+                <span className={cx("dotted-separator")}></span>
+                <span className={cx("summary-element-value")}>
+                  {formatCollateral(category.runningAmount, collateral)}
+                  {category.increment && category.increment.abs().gt(0.01) && (
+                    <span
+                      className={cx("change-percentage", {
+                        negative: category.increment.lt(0)
+                      })}
+                    >
+                      {" "}
+                      {category.increment.toString()}%
+                    </span>
+                  )}
+                </span>
               </div>
             </Fragment>
           ))}

--- a/app/src/Sidebar/components/CategoricalBuy/BuySummary.scss
+++ b/app/src/Sidebar/components/CategoricalBuy/BuySummary.scss
@@ -2,25 +2,18 @@
 @import "../../sidebar.scss";
 
 .summary {
-  &-heading {
-  }
-  
-  &-category {
-    font-size: 1.5rem;
-  
-    .category-values {
-      &-positive {
-        color: $green;
-      }
-    
-      .category-value {    
-        margin: 1rem 0;
+  &-element {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: baseline;
+    padding: 0.5rem 0;
 
-        &.value {
-          font-weight: $bold;
-        }
+    &-value {
+      font-size: 1.5rem;
+      font-weight: $bold;
 
-        .change-percentage {
+      .change-percentage {
           font-weight: $normal;
           color: $green;
 
@@ -28,7 +21,12 @@
             color: $red;
           }
         }
-      }
+    }
+
+    .dotted-separator {
+      border-bottom: 1px dotted $shadeBlue;
+      flex: 1;
+      margin: 0 0.3rem;
     }
   }
 }

--- a/app/src/Sidebar/components/ScalarBuy/profitSimulator.js
+++ b/app/src/Sidebar/components/ScalarBuy/profitSimulator.js
@@ -145,6 +145,16 @@ const profitSimulator = ({
       <div className={cx("invest-summary")}>
         <div className={cx("summary")}>
           <div className={cx("row")}>
+            <span className={cx("label")}>Outcome tokens</span>
+            <span className={cx("spacer")} />
+            <span className={cx("value")}>
+              {new Decimal(profitSim.maxPayout)
+                .div(1e18)
+                .toSignificantDigits(4)
+                .toString()}
+            </span>
+          </div>
+          <div className={cx("row")}>
             <span className={cx("label")}>Max Payout</span>
             <span className={cx("spacer")} />
             <span className={cx("value")}>

--- a/app/src/Sidebar/components/ScalarBuy/profitSimulator.js
+++ b/app/src/Sidebar/components/ScalarBuy/profitSimulator.js
@@ -66,11 +66,6 @@ const profitSimulator = ({
         hasEnteredInvestment ? investmentAmount : zeroDecimal
       );
 
-      // We have to substract the fee
-      const investmentAmountInUnitsAfterFee = investmentAmountInUnits
-        .div(Decimal(1).add(fee))
-        .toDecimalPlaces(0);
-
       const normalizedSlider = new Decimal(sliderValue)
         .sub(decimalLower)
         .div(decimalUpper.sub(decimalLower));
@@ -108,10 +103,7 @@ const profitSimulator = ({
             <span>{formatScalarValue(decimalLower, market.unit)}</span>
             <span>
               {formatScalarValue(
-                decimalUpper
-                  .minus(decimalLower)
-                  .div(2)
-                  .add(decimalLower),
+                decimalUpper.minus(decimalLower).div(2).add(decimalLower),
                 market.unit
               )}
             </span>


### PR DESCRIPTION
# Background
User have some trouble understanding what they get after buying in any Sight market. We will add explicit info about the number of outcome tokens they will get after buying

# To Test
- On a categorical markets test that outcome tokens quantity is shown before buying and is the same showed in quantity column after buy is completed.
- Check that styles match new designs

- On a scalar market check that outcome tokens quantity is shown before buying
- No big changes in designs

# Code
Do some rewording and showing explicitly the number of Outcome Tokens that an user is purchasing.
Updating styles to match new designs