### PR TITLE
Travis CI upload staging to markets path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ deploy:
     secret_access_key: $AWS_SECRET_ACCESS_KEY
     skip_cleanup: true
     local_dir: dist
+    upload-dir: markets
     on:
       branch: development
 
@@ -47,7 +48,7 @@ deploy:
     secret_access_key: $AWS_SECRET_ACCESS_KEY
     skip_cleanup: true
     local_dir: dist
-    upload-dir: current
+    upload-dir: current/markets
     on:
       branch: master
 


### PR DESCRIPTION
 * Add to stage development deployment `upload-dir` parameter to upload
   to `/markets` path.
 * Update to stage staging deployment `upload-dir` parameter to upload
   to `/current/markets` path.